### PR TITLE
improve spacing of top logo, topics, keywords

### DIFF
--- a/paper/juliacon.cls
+++ b/paper/juliacon.cls
@@ -698,9 +698,11 @@ to\hsize{\if@nfeven\else\hfil\fi\box\@tempboxa\if@nfeven\hfil\fi}
 %
 \def\@maketitle{\newpage \thispagestyle{titlepage}\par
  \begingroup \lineskip = \z@\null
+ \vspace{-1.75em}
  \begin{picture}(5,5)
 	\includegraphics[width=1in]{logojuliacon.pdf}
  \end{picture}
+ \vspace{1.75em}
  \vskip -7pt\relax %-18.5pt
  \parindent\z@ \LARGE {\centering \hyphenpenalty\@M
   {\titlefont \@title} \par
@@ -737,10 +739,11 @@ to\hsize{\if@nfeven\else\hfil\fi\box\@tempboxa\if@nfeven\hfil\fi}
 \def\terms#1{\setbox\@terms=\vbox{\hsize20pc%
  \footnotesize%
 \parindent 0pt \noindent
- { \section*{General Terms}} \ignorespaces #1}}
+ {	 \section*{General Terms}} \ignorespaces #1}}
 \def\keywords#1{\gdef\@keywords{\hsize20pc%
 \parindent 0pt\noindent\ignorespaces%
- { \section*{Keywords} } \ignorespaces #1}
+ {\vspace{-1em}%
+ 	 \section*{Keywords} } \ignorespaces #1{\vspace{1em}}}
 }
 
 \def\category#1#2#3{\@ifnextchar


### PR DESCRIPTION
These changes do a decent job of moving the logo to align with the top of the printing on additional pages and separate it from the article title.  If you prefer that the logo stay where it was, and the article title move down -- that is easy enough (please let me know).  The spacing between the Abstract and the keywords or the topics and keywords is more natural.  There is one __flaw__:  if the author specifies topics but does not specify any keywords, then there is a `!` that appears after the topics ... I do not know what causes that.
Again .. let me know if you prefer the prior spacing if it does not make the `!` appear [I did not check for that].