### PR TITLE
move logo up, improve spacing for topics, keywords

### DIFF
--- a/paper/juliacon.cls
+++ b/paper/juliacon.cls
@@ -698,9 +698,11 @@ to\hsize{\if@nfeven\else\hfil\fi\box\@tempboxa\if@nfeven\hfil\fi}
 %
 \def\@maketitle{\newpage \thispagestyle{titlepage}\par
  \begingroup \lineskip = \z@\null
+ \vspace{-1.75em}
  \begin{picture}(5,5)
 	\includegraphics[width=1in]{logojuliacon.pdf}
  \end{picture}
+ \vspace{1.75em}
  \vskip -7pt\relax %-18.5pt
  \parindent\z@ \LARGE {\centering \hyphenpenalty\@M
   {\titlefont \@title} \par
@@ -727,21 +729,22 @@ to\hsize{\if@nfeven\else\hfil\fi\box\@tempboxa\if@nfeven\hfil\fi}
 \newbox\@terms
 \newbox\@keywords
 
+
 %
 \newenvironment{abstract}
-	       {\section*{ABSTRACT}\par\fontsize{10}{12}\indent\ignorespaces}
-	       {
-		   { \ifvoid\@terms\else\box\@terms\fi
- \@keywords \@juliaconformat\empty}\vskip6pt}
+{\section*{ABSTRACT}\par\fontsize{10}{12}\indent\ignorespaces}
+{
+	{ \ifvoid\@terms\else\box\@terms\fi
+		\@keywords \@juliaconformat\empty}\vskip6pt}
 %
 \def\terms#1{\setbox\@terms=\vbox{\hsize20pc%
- \footnotesize%
-\parindent 0pt \noindent
- { \section*{General Terms}} \ignorespaces #1}}
+		\footnotesize%
+		\parindent 0pt \noindent
+		{ \section*{General Terms}} \ignorespaces #1{\vspace{-0.75em}}}}
 \def\keywords#1{\gdef\@keywords{\hsize20pc%
-\parindent 0pt\noindent\ignorespaces%
- { \section*{Keywords} } \ignorespaces #1}
-}
+		\parindent 0pt\noindent\ignorespaces%
+		{{\vspace{-0.75em}} \section*{Keywords}} \ignorespaces #1{\vspace{1em}}}}
+%}
 
 \def\category#1#2#3{\@ifnextchar
  [{\@category{#1}{#2}{#3}}{\@xcategory{#1}{#2}{#3}}}


### PR DESCRIPTION
Try it, see if you prefer this.  If you want the logo to stay where it was and just move the title down, let me know. 
There is one issue:  if the author specifies topics and does not specify keywords, then a '!' appears after the topics -- I do not know the cause or the fix.  [I'd tell any authors who list topics and not keywords to make the topics list a keywords list ... until the actual cause and fix are available]