### PR TITLE
Fixes issue 31 related to listing captions

### DIFF
--- a/paper/header.tex
+++ b/paper/header.tex
@@ -12,7 +12,7 @@
 
 \hypersetup{
 pdftitle = {My JuliaCon proceeding},
-pdfsubject = {JuliaCon 2019 Proceedings},
+pdfsubject = {JuliaCon 2022 Proceedings},
 pdfauthor = {1st author, 2nd author, 3rd author},
 pdfkeywords = {Julia, Optimization, Game theory, Compiler},
 }

--- a/paper/journal_dat.tex
+++ b/paper/journal_dat.tex
@@ -3,4 +3,4 @@
 \def\@journalName{Proceedings of JuliaCon}
 \def\@volume{1}
 \def\@issue{1}
-\def\@year{2021}
+\def\@year{2022}

--- a/paper/juliacon.cls
+++ b/paper/juliacon.cls
@@ -939,6 +939,11 @@ to\hsize{\if@nfeven\else\hfil\fi\box\@tempboxa\if@nfeven\hfil\fi}
 
 \usepackage{authblk}
 
+% Fixes issue related to listing captions: https://github.com/JuliaCon/JuliaConSubmission.jl/issues/31
+\usepackage{caption}
+\captionsetup[lstlisting]{singlelinecheck=false, margin=0pt}
+\renewcommand\lstlistingname{Code}
+
 \endinput
 
 % end of juliacon.cls

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -166,7 +166,7 @@ A special environment is already defined for Julia code,
 built on top of \textit{listings} and \textit{jlcode}.
 
 \begin{verbatim}
-\begin{lstlisting}[language = Julia]
+\begin{lstlisting}[language = Julia, numbers=left, label={lst:exmplg}, caption={Example Code Block.}]
 using Plots
 
 x = -3.0:0.01:3.0
@@ -174,7 +174,7 @@ y = rand(length(x))
 plot(x, y)
 \end{lstlisting}
 \end{verbatim}
-\begin{lstlisting}[language = Julia]
+\begin{lstlisting}[language = Julia, numbers=left, label={lst:exmplg}, caption={Example Code Block.}]
 using Plots
 
 x = -3.0:0.01:3.0

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -166,7 +166,12 @@ A special environment is already defined for Julia code,
 built on top of \textit{listings} and \textit{jlcode}.
 
 \begin{verbatim}
-\begin{lstlisting}[language = Julia, numbers=left, label={lst:exmplg}, caption={Example Code Block.}]
+\begin{lstlisting}[
+    language = Julia, 
+    numbers=left, 
+    label={lst:exmplg}, 
+    caption={Example Code Block.}
+]
 using Plots
 
 x = -3.0:0.01:3.0
@@ -174,7 +179,12 @@ y = rand(length(x))
 plot(x, y)
 \end{lstlisting}
 \end{verbatim}
-\begin{lstlisting}[language = Julia, numbers=left, label={lst:exmplg}, caption={Example Code Block.}]
+\begin{lstlisting}[
+    language = Julia, 
+    numbers=left, 
+    label={lst:exmplg}, 
+    caption={Example Code Block.}
+]
 using Plots
 
 x = -3.0:0.01:3.0


### PR DESCRIPTION
Fixes #31 

Not a $\LaTeX$ expert by any means, so perhaps there's a better way to do this, but it's working as intended. From the rendered template:

![image](https://github.com/JuliaCon/JuliaConSubmission.jl/assets/55311242/fa6adcee-91e4-4814-be6e-6d2eccb45d9c)

